### PR TITLE
Minor output directory tweaks

### DIFF
--- a/FunKiiU.py
+++ b/FunKiiU.py
@@ -183,9 +183,9 @@ def makeTicket(titleid, key, titleversion, fulloutputpath):
 def processTitleID(titleid, key):
 
     if(arguments.output_dir is not None):
-        rawdir = os.path.join(arguments.output_dir, 'output', titleid)
+        rawdir = os.path.join('install', arguments.output_dir)
     else:
-        rawdir = os.path.join('output', titleid)
+        rawdir = os.path.join('install', titleid)
 
     if not os.path.exists(rawdir):
         os.makedirs(os.path.join(rawdir))

--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ which gives everything with one of those 'brazil' tickets, downloaded from *they
 this ticket is basically a legit ticket so once installed:
 
 **the game will work without hacks**
+
+
+If desired you can also install to a custom directory using the -outputdir tag. This makes it more convinient to determine what title the files go to. Using the above example you would do this:
+
+`python FunKiiU.py -outputdir pikmin_3 -title 000500001012be00 -onlinetickets`
+
+**this will install the files to /install/pikmin_3**


### PR DESCRIPTION
Output directory changed from 'Output' to 'Install' allowing for easier naming conventions when utilizing WUPinstaller. -outputdit tag changed to allow the custom directory to be placed inside the 'Install' folder, reducing confusion about what is contained in the folder.